### PR TITLE
Use correct MIME type for API requests

### DIFF
--- a/client/common/api.js
+++ b/client/common/api.js
@@ -135,6 +135,7 @@ function send_query(name, query, cb, polling) {
 		$.ajax({
 			type : "POST",
 			url : URL + "action/" + name,
+			contentType : "application/json",
 			data : post,
 			timeout : polling ? TIMEOUT_POLLING : TIMEOUT_QUERY,
 			success : function (res) {


### PR DESCRIPTION
Using `application/x-www-form-urlencoded` instead of `application/json` might cause problems with some client browsers.
